### PR TITLE
helper: Add npm install before npm test

### DIFF
--- a/frigg/helpers.py
+++ b/frigg/helpers.py
@@ -36,7 +36,7 @@ def _detect_test_runners(files):
     if 'manage.py' in files:
         return ['python manage.py test', 'flake8']
     if 'package.json' in files:
-        return ['npm test']
+        return ['npm install', 'npm test']
     if 'build.sbt' in files:
         return ['sbt test']
     if 'Cargo.toml' in files:


### PR DESCRIPTION
https://ci.frigg.io/haeric/bailey.js/1/ failed because it didn't have pegjs... this might work? :)
