### PR TITLE
Fix #24, use rob to store information about builds in redis

### DIFF
--- a/frigg/worker/fetcher.py
+++ b/frigg/worker/fetcher.py
@@ -24,3 +24,4 @@ def start_build(json_string):
     build = Build(task['id'], task)
     logger.info('Starting %s' % task)
     build.run_tests()
+    build.delete()

--- a/frigg/worker/jobs.py
+++ b/frigg/worker/jobs.py
@@ -4,11 +4,13 @@ import os
 import yaml
 import logging
 
+from rob.mixins import AutosaveMixin
+from rob.objects import JsonObject
 from fabric.context_managers import lcd
 from frigg import api
 
 from frigg.helpers import local_run, detect_test_runners, cached_property
-from .config import config, sentry
+from .config import config, sentry, redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +37,10 @@ class Result(object):
         return obj.__dict__
 
 
-class Build(object):
+class Build(JsonObject, AutosaveMixin):
+    HASH_KEY = 'frigg:builds'
+    redis = redis_client()
+
     id = ''
     results = []
     cloned = False
@@ -49,6 +54,7 @@ class Build(object):
 
     def __init__(self, build_id, obj):
         self.__dict__.update(obj)
+        self.key = build_id
         self.id = build_id
         self.results = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pyyaml
 redis
 requests
 raven
+rob
 
 # testing tools
 pytest

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         'redis',
         'pyyaml',
         'requests',
-        'raven'
+        'raven',
+        'rob'
     ],
     entry_points={
         'console_scripts': ['frigg-worker = frigg.worker.cli:main']


### PR DESCRIPTION
This will make it possible for frigg to check in and print intermidiate
results on the web page.