### PR TITLE
Add catching ConnectionError in fetch_task

### DIFF
--- a/.frigg.yml
+++ b/.frigg.yml
@@ -1,7 +1,7 @@
 tasks:
- - tox
- - flake8
+ - tox -e flake8
  - isort -c -rc frigg_worker tests
+ - tox -e tests
  - coverage report && coverage xml
 
 coverage:

--- a/frigg_worker/fetcher.py
+++ b/frigg_worker/fetcher.py
@@ -40,17 +40,20 @@ def start_build(task, options):
 
 def fetch_task(dispatcher_url, dispatcher_token):
     logger.debug('Fetching new job from {0}'.format(dispatcher_url))
-    response = requests.get(
-        dispatcher_url,
-        headers={
-            'x-frigg-worker-token': dispatcher_token
-        }
-    )
+    try:
+        response = requests.get(
+            dispatcher_url,
+            headers={
+                'x-frigg-worker-token': dispatcher_token
+            }
+        )
 
-    if response.status_code == 200:
-        return response.json()['job']
-    else:
-        time.sleep(20)
+        if response.status_code == 200:
+            return response.json()['job']
+    except requests.exceptions.ConnectionError as e:
+        logger.exception(e)
+
+    time.sleep(20)
 
 
 def notify_of_upstart(options):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -36,3 +36,11 @@ class FetcherTestCase(TestCase):
 
         task = fetch_task('http://example.com', None)
         self.assertEqual(task['id'], 1)
+
+    @patch('time.sleep')
+    @patch('requests.packages.urllib3.response.HTTPResponse.from_httplib',
+           side_effect=TimeoutError())
+    def test_fetch_task_should(self, mock_send, mock_sleep):
+        fetch_task('http://example.com', None)
+        mock_sleep.assert_called_once_with(20)
+        mock_send.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
-envlist = py34
+envlist = tests,flake8
 skipsdist = True
 
 [testenv]
+basepython = python3.4
 deps =
-    -r{toxinidir}/requirements.txt
+    tests: -r{toxinidir}/requirements.txt
+    flake8: flake8
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
     TESTING = True
 commands =
-    coverage run --source=frigg_worker -m py.test -v tests
+    tests: coverage run --source=frigg_worker -m py.test -v tests
+    flake8: flake8


### PR DESCRIPTION
This will fix the problem with workers crashing on network errors.

---------------------------
It was necessary to use tox with flake8 in order to avoid error on `TimeoutError`, since it is only a builtin type in python 3.