### PR TITLE
Add presets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include setup.py README.md MANIFEST.in LICENSE
+include setup.py README.md MANIFEST.in LICENSE frigg_worker/presets.yaml

--- a/frigg_worker/deployments.py
+++ b/frigg_worker/deployments.py
@@ -1,4 +1,6 @@
 import logging
+import os
+
 import yaml
 
 from .jobs import Job, Result
@@ -81,7 +83,7 @@ class Deployment(Job):
         Loads preset if it is specified in the .frigg.yml
         """
         if 'preset' in self.settings['preview']:
-            with open('frigg_worker/presets.yaml') as f:
+            with open(os.path.join(os.path.dirname(__file__), 'presets.yaml')) as f:
                 presets = yaml.load(f.read())
 
             if self.settings['preview']['preset'] in presets:

--- a/frigg_worker/presets.yaml
+++ b/frigg_worker/presets.yaml
@@ -8,14 +8,14 @@ django-py2:
   - pip install -U gunicorn -r requirements.txt
   - python manage.py migrate
   - python manage.py collectstatic --noinput
- daemon_task: gunicorn -D -b 0.0.0.0:8000 frigg.wsgi
+ daemon_task: nohup python manage.py runserver 0.0.0.0:8000 &
 
 django-py3:
  tasks:
   - pip3 install -U gunicorn -r requirements.txt
   - python3 manage.py migrate
   - python3 manage.py collectstatic --noinput
- daemon_task: gunicorn -D -b 0.0.0.0:8000 frigg.wsgi
+ daemon_task: nohup python3 manage.py runserver 0.0.0.0:8000 &
 
 express:
  tasks:

--- a/frigg_worker/presets.yaml
+++ b/frigg_worker/presets.yaml
@@ -1,0 +1,24 @@
+scripts:
+ tasks:
+  - ./scripts/install
+ daemon_task: PORT=8000 ./scripts/server
+
+django-py2:
+ tasks:
+  - pip install -U gunicorn -r requirements.txt
+  - python manage.py migrate
+  - python manage.py collectstatic --noinput
+ daemon_task: gunicorn -D -b 0.0.0.0:8000 frigg.wsgi
+
+django-py3:
+ tasks:
+  - pip3 install -U gunicorn -r requirements.txt
+  - python3 manage.py migrate
+  - python3 manage.py collectstatic --noinput
+ daemon_task: gunicorn -D -b 0.0.0.0:8000 frigg.wsgi
+
+express:
+ tasks:
+  - npm install
+  - npm install -g forever
+ daemon_task: PORT=8000 forever start index.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,4 @@ pyyaml==3.11
 # testing tools
 pytest
 coverage
-mock
 responses

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -1,7 +1,7 @@
 # -*- coding: utf8 -*-
 import unittest
+from unittest import mock
 
-import mock
 from docker.manager import Docker
 
 from frigg_worker.builds import Build

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
+from unittest.mock import patch
 
 from click.testing import CliRunner
-from mock import patch
 
 from frigg_worker.cli import start
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -85,7 +85,7 @@ class DeploymentTests(unittest.TestCase):
     @mock.patch('frigg_worker.deployments.Deployment.report_run', lambda *x: None)
     @mock.patch('frigg_worker.deployments.Deployment.load_preset')
     @mock.patch('frigg_worker.deployments.Deployment.run_task')
-    def test_run_deploy(self, mock_run_task, mock_load_preset):
+    def test_run_deploy_should_load_preset(self, mock_run_task, mock_load_preset):
         self.deployment.run_deploy()
         self.assertTrue(mock_load_preset.called)
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,7 +1,7 @@
 # -*- coding: utf8 -*-
 import unittest
+from unittest import mock
 
-import mock
 from docker.manager import Docker
 
 from frigg_worker.deployments import Deployment

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 from unittest import TestCase
+from unittest.mock import patch
 
 import responses
-from mock import patch
 
 from frigg_worker.fetcher import fetch_task, start_build
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,7 +1,7 @@
 # -*- coding: utf8 -*-
 import unittest
+from unittest import mock
 
-import mock
 from docker.helpers import ProcessResult
 from docker.manager import Docker
 from raven import Client


### PR DESCRIPTION
This is opened a bit early to get feedback on the yaml structure.

The idea is that preview runs:
1. `setup_tasks`
2. `preset.tasks`
3. `preview.tasks` - load data here
4. `preset.daemon_task`

cc: @frecar 